### PR TITLE
Set lsstDocType to OPSTN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ meta.tex: Makefile .FORCE
 	rm -f $@
 	touch $@
 	echo '% GENERATED FILE -- edit this in the Makefile' >>$@
-	/bin/echo '\newcommand{\lsstDocType}{$(DOCTYPE)}' >>$@
+	/bin/echo '\newcommand{\lsstDocType}{OPSTN}' >>$@
 	/bin/echo '\newcommand{\lsstDocNum}{$(DOCNUMBER)}' >>$@
 	/bin/echo '\newcommand{\vcsrevision}{$(GITVERSION)$(GITDIRTY)}' >>$@
 	/bin/echo '\newcommand{\vcsdate}{$(GITDATE)}' >>$@


### PR DESCRIPTION
This ensures that the document's type is correctly identified for search ingest — it's necessary for the document to be categorized correctly on www.lsst.io.